### PR TITLE
SoundPlayer에서 작동 하지 않는 코드 삭제

### DIFF
--- a/Assets/SC KRM/Sound/SoundPlayer.cs
+++ b/Assets/SC KRM/Sound/SoundPlayer.cs
@@ -127,14 +127,7 @@ namespace SCKRM.Sound
 
 
 
-        void OnAudioFilterRead(float[] data, int channels)
-        {
-#if UNITY_EDITOR
-            if (UnityEditor.EditorApplication.isCompiling)
-                return;
-#endif
-            onAudioFilterReadEvent?.Invoke(data, channels);
-        }
+        void OnAudioFilterRead(float[] data, int channels) => onAudioFilterReadEvent?.Invoke(data, channels);
 
 
 


### PR DESCRIPTION
컴파일시에 오디오가 끊기는것을 해결할 목적으로 코드를 추가했지만,
실질적으로 작동하지 않는것을 확인했습니다
유니티 내부의 문제같습니다